### PR TITLE
Update pawn.json

### DIFF
--- a/pawn.json
+++ b/pawn.json
@@ -5,7 +5,7 @@
   "output": "test/gamemodes/test.amx",
   "dependencies": [
     "sampctl/samp-stdlib",
-    "katursis/Pawn.RakNet"
+    "katursis/Pawn.RakNet:1.6.0"
   ],
   "dev_dependencies": ["pawn-lang/YSI-Includes"],
   "runtime": {


### PR DESCRIPTION
Pawn.Raknet ตัวล่าสุดเป็นของ omp เลยจำเป็นต้องกำหนดเลขเวอร์ชั่นไว้สักหน่อยครับ เพราะของ samp กับ open.mp ใช้ด้วยกันไม่ได้